### PR TITLE
fix: Resolve ESLint error in app/event/0/page.tsx

### DIFF
--- a/app/event/0/page.tsx
+++ b/app/event/0/page.tsx
@@ -22,14 +22,14 @@ export default function Event0Page() {
           <p className="text-sm text-muted-foreground select-none">
             2つ以上選んで投票を作成する
           </p>
-          {isClient && (
+          {isClient ? (
             <Calendar
               mode="multiple"
               selected={selectedDates}
               onSelect={setSelectedDates}
               initialFocus
             />
-          )}
+          ) : null}
       <div className="flex mt-4 space-x-2">
         <Button variant="outline" onClick={() => setSelectedDates([])} className="select-none">
           リセット


### PR DESCRIPTION
このコミットは、`app/event/0/page.tsx` の Vercel デプロイ時に 26 行目で報告された LintError に対処します。

`Calendar` コンポーネントの条件付きレンダリングが `&&` から `null` を含む三項演算子に変更されました。これは、Vercel のビルド環境によって強制される可能性のあるクライアント側レンダリングパターンに関連する、微妙な ESLint ルール違反を解消することを目的としています。