### PR TITLE
fix: Correct sonner integration with shadcn/ui

### DIFF
--- a/components/share-button.tsx
+++ b/components/share-button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { Share2, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { toast } from "@/components/ui/sonner"; // Using shadcn/ui sonner for toasts
+import { toast } from "sonner"; // Using sonner for toasts
 
 interface ShareButtonProps {
   url: string;


### PR DESCRIPTION
This commit rectifies the incorrect integration of `sonner` with `shadcn/ui`. It was previously misunderstood that `shadcn/ui`'s `sonner` component would provide the `toast` function directly.

Changes include:
- Reinstalled the `sonner` package as it is required for the `toast` function.
- Reverted the import path for `toast` in `share-button.tsx` back to `sonner`.
- The `components/ui/sonner.tsx` file remains as it provides the themed `Toaster` component.