### PR TITLE
feat: Apply spot-list design to event pages and refine UI elements

### DIFF
--- a/app/event/0/done/page.tsx
+++ b/app/event/0/done/page.tsx
@@ -13,7 +13,7 @@ export default function Event0DonePage() {
   }, []);
 
   return (
-    <div className="pt-20 text-center">
+    <div className="flex flex-col justify-center items-center h-screen pt-20 font-sans bg-orange-50">
       <h1 className="text-2xl font-bold mb-4">開催日の投票を作成しました！</h1>
       <div className="flex w-full max-w-sm items-center space-x-2 mx-auto">
         <Input type="text" value={shareUrl} readOnly />

--- a/app/event/0/page.tsx
+++ b/app/event/0/page.tsx
@@ -15,8 +15,8 @@ export default function Event0Page() {
   }, []);
 
   return (
-    <div className="flex flex-col justify-center items-center h-full pt-20">
-                <h2 className="text-xl font-bold tracking-tight select-none">
+    <div className="flex flex-col justify-center items-center h-screen pt-20 font-sans bg-orange-50">
+                <h2 className="text-xl font-bold tracking-tight select-none text-gray-900">
             予定日を選んでください
           </h2>
           <p className="text-sm text-muted-foreground select-none">
@@ -27,11 +27,11 @@ export default function Event0Page() {
               mode="multiple"
               selected={selectedDates}
               onSelect={setSelectedDates}
-              initialFocus
+              
             />
           ) : null}
       <div className="flex mt-4 space-x-2">
-        <Button variant="outline" onClick={() => setSelectedDates([])} className="select-none">
+        <Button variant="outline" onClick={() => setSelectedDates([])} className="select-none text-gray-900 bg-[var(--color-calendar-background)] hover:text-[var(--color-calendar-text)]">
           リセット
         </Button>
         <Button onClick={() => router.push("/event/0/done")} disabled={selectedDates.length < 2} className="select-none">

--- a/app/event/1/page.tsx
+++ b/app/event/1/page.tsx
@@ -1,6 +1,6 @@
 export default function Event1Page() {
   return (
-    <div>
+    <div className="min-h-screen font-sans bg-orange-50">
       <h1>Event 1</h1>
     </div>
   );

--- a/app/event/2/page.tsx
+++ b/app/event/2/page.tsx
@@ -1,6 +1,6 @@
 export default function Event2Page() {
   return (
-    <div>
+    <div className="min-h-screen font-sans bg-orange-50">
       <h1>Event 2</h1>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -41,6 +41,12 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+
+  /* Custom colors for specific components */
+  --color-header-background: #FFFFFF;
+  --color-header-text: #333333;
+  --color-calendar-background: #FFFFFF;
+  --color-calendar-text: #000000;
 }
 
 :root {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       suppressHydrationWarning
     >
-      <body>
+      <body className="min-h-screen">
         <ThemeProvider
           attribute="class"
           defaultTheme="dark"

--- a/app/spot-list/page.tsx
+++ b/app/spot-list/page.tsx
@@ -120,7 +120,7 @@ const SpotCard = ({
   store: Store;
   onCountUp: (id: number, type: "like" | "save") => void;
 }) => (
-  <Card className="border-2 border-orange-200 bg-white shadow-lg rounded-xl overflow-hidden mb-3">
+  <Card className="border-2 border-gray-300 bg-white shadow-lg rounded-xl overflow-hidden mb-3">
     <CardContent className="p-3">
       <div className="flex flex-row space-x-4">
         {/* 画像コンテナ */}
@@ -165,7 +165,11 @@ const SpotCard = ({
             <div className="flex flex-wrap gap-1.5">
               <Tag className="h-5 w-5 mr-1 text-orange-500" />
               {store.tags.map((tag) => (
-                <Badge key={tag} variant="secondary" className="text-xs">
+                <Badge
+                  key={tag}
+                  variant="secondary"
+                  className="text-xs bg-[var(--color-calendar-background)] text-[var(--color-calendar-text)]"
+                >
                   {tag}
                 </Badge>
               ))}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,11 +1,17 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 export default function Header() {
+  const pathname = usePathname();
+  const isEventPageOrSpotListPage = pathname.startsWith("/event") || pathname.startsWith("/spot-list");
+
   return (
-    <header className="fixed top-0 left-0 right-0 z-10 bg-background border-b">
+    <header className={`fixed top-0 left-0 right-0 z-10 border-b ${isEventPageOrSpotListPage ? "bg-[var(--color-header-background)]" : "bg-[var(--color-background)]"}`}>
       <nav className="container mx-auto px-4 py-2 flex justify-between items-center">
         <div className="flex items-center space-x-4">
-            <Link href="/" className="text-lg font-bold">
+            <Link href="/" className="text-lg font-bold text-[var(--color-header-text)]">
                 GourCommu
             </Link>
         </div>

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -31,7 +31,7 @@ function Calendar({
       locale={ja}
       showOutsideDays={showOutsideDays}
       className={cn(
-        "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        "bg-[var(--color-calendar-background)] group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className
@@ -82,7 +82,7 @@ function Calendar({
           defaultClassNames.dropdown
         ),
         caption_label: cn(
-          "select-none font-medium",
+          "select-none font-medium text-gray-900", // Added text-gray-900
           captionLayout === "label"
             ? "text-sm"
             : "rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5",
@@ -104,7 +104,7 @@ function Calendar({
           defaultClassNames.week_number
         ),
         day: cn(
-          "relative w-full h-full p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none",
+          "relative w-full h-full p-0 text-center text-[var(--color-calendar-text)] [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none",
           defaultClassNames.day
         ),
         range_start: cn(


### PR DESCRIPTION
このコミットでは、`spot-list` ページのデザイン要素をすべての `event` ページに適用することで、視覚的な一貫性を実現します。

変更点は以下のとおりです。
- `app/event/0/page.tsx`、`app/event/0/done/page.tsx`、`app/event/1/page.tsx`、`app/event/2/page.tsx` のメインコンテナに `font-sans` クラスと `bg-orange-50` クラスを適用しました。
- `app/event/0/done/page.tsx` で解析エラーを引き起こしていた構文エラーを修正しました。
- `app/layout.tsx` の `body` タグに `min-h-screen` を追加し、背景がビューポートの下部まで広がるようにしました。
- ルートに応じて条件付きでヘッダーに `bg-white` を適用しました（`/event/*` および `/spot-list` ページでは白、それ以外の場合は `bg-background`）。
- ヘッダーのテキスト色を `text-[var(--color-header-text)]`（灰色として定義）に変更しました。
- `DayPicker` コンポーネントに `bg-[var(--color-calendar-background)]` を適用しました。
- カレンダーの日付に `text-[var(--color-calendar-text)]` を適用しました。
- リセットボタンに `bg-[var(--color-calendar-background)]` を適用しました。
- ホバー時のリセットボタンに `text-[var(--color-calendar-text)]` を適用しました。
- `spot-list` タグ (バッジコンポーネント) に `bg-[var(--color-calendar-background)]` と `text-[var(--color-calendar-text)]` を適用しました。
- `spot-list` カードの枠線を `border-gray-300` に変更しました。